### PR TITLE
use new full list URL for hPSCreg

### DIFF
--- a/scripts/elasticsearch/populate_cell_line.from_cgap_report.pl
+++ b/scripts/elasticsearch/populate_cell_line.from_cgap_report.pl
@@ -89,7 +89,7 @@ my $hESCreg = ReseqTrack::EBiSC::hESCreg->new(
 );
 my %ebisc_names;
 LINE:
-foreach my $ebisc_name (@{$hESCreg->find_lines(url=>"/api/full_list/hipsci")}) {
+foreach my $ebisc_name (@{$hESCreg->find_lines(url=>"/api/export/hipsci")}) {
   next LINE if $ebisc_name !~ /^WTSI/;
   my $line = eval{$hESCreg->get_line($ebisc_name);};
   next LINE if !$line || $@;


### PR DESCRIPTION
The new URL is
hpscreg.eu/api/export/hipsci
This only lists HipSci (WTSI) lines.

see also https://github.com/EMBL-EBI-GCA/gca_ebisc/pull/2